### PR TITLE
Fix fees not calculated for first account to provide liquidity on a pair

### DIFF
--- a/src/utils/returns.ts
+++ b/src/utils/returns.ts
@@ -109,8 +109,16 @@ export function getMetricsForPositionWindow(positionT0: Position, positionT1: Po
   positionT1 = formatPricesForEarlyTimestamps(positionT1)
 
   // calculate ownership at ends of window, for end of window we need original LP token balance / new total supply
-  const t0Ownership = positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply
-  const t1Ownership = positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply
+  // eslint-disable-next-line eqeqeq
+  const t0Ownership =
+      positionT0.liquidityTokenTotalSupply != 0
+          ? positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply
+          : 0
+  // eslint-disable-next-line eqeqeq
+  const t1Ownership =
+      positionT1.liquidityTokenTotalSupply != 0
+          ? positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply
+          : 0
 
   // get starting amounts of token0 and token1 deposited by LP
   const token0_amount_t0 = t0Ownership * positionT0.reserve0


### PR DESCRIPTION
This is a fix for an issue originally raised on [Uniswap](https://github.com/Uniswap/uniswap-info/issues/363). The Pangolin code is the same so the issue is also present here. 
If an account is the first to provide liquidity on a pair, the calculation of their ownership of the pool when they entered it will return a `NaN` because it will try to divide by a `liquidityTokenTotalSupply` that is equal to 0. The ownership `NaN` at t0 will then affect all subsequent calculations, including the sum of fees. Consequently the fees will not be displayed on the interface.

Note: this should not affect #13 and #14 on which another user is currently working.